### PR TITLE
refactor: Clean up testblockchain code

### DIFF
--- a/utils/testblockchain.py
+++ b/utils/testblockchain.py
@@ -1,8 +1,27 @@
+"""
+This utility function allows for the download of a recent chunk of the blockchain.
+It's useful for testing and continuing through the YetiCold process, but not for
+actual wallet use. ~/.bitcoin folder should be deleted before using YetiCold for
+real.
+"""
+
 import os
 import subprocess
-home = os.getenv("HOME")
-if not (os.path.exists(home + "/.bitcoin")):
-	subprocess.call(['cd ~/yeticold/utils; rm ~/yeticold/utils/.bitcoin.tar.gz; perl gdown.pl https://drive.google.com/file/d/1iTLKVLkvAaGRDE7dnLpSR5Hl4I-Xnyft/view?usp=sharing .bitcoin.tar.gz; rm -r ~/yeticold/utils/.bitcoin; tar -xzvf .bitcoin.tar.gz .bitcoin; cd'],shell=True)
-	subprocess.call(['mv ~/yeticold/utils/.bitcoin ~/'],shell=True)
-	subprocess.call(['rm ~/testblockchain'],shell=True)
 
+
+# Function which can be called if this script is imported
+def get_test_blockchain():
+    if not os.path.exists(os.path.join(os.getenv("HOME"), ".bitcoin")):
+        print("Cleaning out old files...")
+        subprocess.run('rm -f ~/yeticold/utils/.bitcoin.tar.gz && rm -rf ~/yeticold/utils/.bitcoin', shell=True, check=False)
+        print("Downloading test blockchain file...")
+        subprocess.run('cd ~/yeticold/utils && perl gdown.pl https://drive.google.com/file/d/1iTLKVLkvAaGRDE7dnLpSR5Hl4I-Xnyft/view?usp=sharing .bitcoin.tar.gz', shell=True, check=False)
+        print("Unzipping test blockchain data...")
+        subprocess.run('cd ~/yeticold/utils && tar -xzf .bitcoin.tar.gz .bitcoin && rm -f ~/yeticold/utils/.bitcoin.tar.gz', shell=True, check=False)
+        print("Relocating unzipped data...")
+        subprocess.run('cd ~ && mv ~/yeticold/utils/.bitcoin ~/', shell=True, check=False)
+
+# If script is run as standalone (not imported) then it will execute the following commands
+if __name__ == "__main__":
+    get_test_blockchain()
+    


### PR DESCRIPTION
'rm ~/testblockchain' wasn't needed as that folder is never created.

Use os.path.join for contructing folder and file paths in an agnostic
way.

Convert the subprocess.call functions into
subprocess.run functions

Replace ; in bash command with && so it only runs if the previous was
successful

Change `cd` to `cd ~` for clarity and explicitness

Allow for importing script for future improvements but don't change
current functionality and implementation