### PR TITLE
refactor: Rework network disable process

### DIFF
--- a/appyeticold.py
+++ b/appyeticold.py
@@ -34,6 +34,7 @@ oldkeys = None
 #FILE IMPORTS
 sys.path.append(home + '/yeticold/utils/')
 from formating import *
+import forgetnetworks
 
 #RPC
 rpcpsw = str(random.randrange(0,1000000))
@@ -221,8 +222,7 @@ def YCRopenbitcoinB():
 @app.route("/YCRconnection", methods=['GET', 'POST'])
 def YCRconnection():
     if request.method == 'POST':
-        subprocess.call(['python3 ~/yeticold/utils/forgetnetworks.py'],shell=True)
-        subprocess.call(['nmcli n off'],shell=True)
+        forgetnetworks.forget_networks()
         return redirect('/YCRswitchlaptop')
     return render_template('YCRconnection.html')
 
@@ -765,8 +765,7 @@ def YCopenbitcoinB():
 @app.route("/YCconnection", methods=['GET', 'POST'])
 def YCconnection():
     if request.method == 'POST':
-        subprocess.call(['python3 ~/yeticold/utils/forgetnetworks.py'],shell=True)
-        subprocess.call(['nmcli n off'],shell=True)
+        forgetnetworks.forget_networks()
         return redirect('/YCgetseeds')
     return render_template('YCconnection.html')
 

--- a/utils/forgetnetworks.py
+++ b/utils/forgetnetworks.py
@@ -1,11 +1,29 @@
+"""
+This script automates the action of disconnecting the computer from any wireless or cabled networks.
+The purpose of this is to disable internet connectivity before generating private keys.
+The disabled network (at least the cabled kind) can be restored using `nmcli n on` and rebooting.
+Though that is only advised during testing. It is not advised for normal usage.
+"""
+
 import subprocess
 import os
 
-res = subprocess.Popen("nmcli -t -f TYPE,UUID con",shell=True,stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0].decode("utf-8")
-lines = res.split('\n')
+def forget_networks():
+    # Get list of wireless access points
+    res = subprocess.Popen("nmcli -t -f TYPE,UUID con", shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0].decode("utf-8")
+    # Split the lines by newline character
+    lines = res.split('\n')
 
-for line in lines:
-    parts = line.split(":")
-    if (parts[0] == "802-11-wireless"):
-        os.system("nmcli connection delete uuid "+ parts[1])
+    # Loop through each line, splitting it by a colon, until a wireless access point is found, then delete it
+    for line in lines:
+        parts = line.split(":")
+        if parts[0] == "802-11-wireless":
+            os.system("nmcli connection delete uuid " + parts[1])
 
+    # Disable all networking system wide
+    subprocess.call(['nmcli n off'], shell=True)
+
+# If script is run as standalone (not imported) then it will execute the following commands
+if __name__ == "__main__":
+    forget_networks()
+    


### PR DESCRIPTION
The network disable commands were consolidated from the appyeticold.py
script into the
forgetnetworks.py script for consistency and maintainance.

Added ability to import functionality of forgetnetworks.py for cleanliness.
Also retained standalone functionality.

FUTURE implementation of disconnecting the user from the internet
when generating private keys should be reconsidered. My favorite idea for
now is to check for internet connectivity before generating keys by
pinging an address. If no response, then continue, if response, then tell
user that process cannot continue until network connectivity is disabled
(by turning off device wifi and/or by disconnecting LAN cable).