### PR TITLE
draft: bump Bitcoin Core to v27.0

### DIFF
--- a/utils/downloadbitcoin.py
+++ b/utils/downloadbitcoin.py
@@ -22,5 +22,5 @@ if not os.path.exists(BitcoinExtractDir):
 		subprocess.call(['echo "Successfully verified the bitcoin core code."'],shell=True)
 	subprocess.call(['mkdir ' + BitcoinExtractDir],shell=True)
 	subprocess.call(['tar -xvzf ' + YetiDir + '/' + BitcoinCoreFile + ' -C ' + BitcoinExtractDir + '/ --strip-components=1'],shell=True)
-	subprocess.call(['chmod u+x ' + YetiDir + '/bin/bitcoin-qt'],shell=True)
-	subprocess.call(['chmod u+x ' + YetiDir + '/bin/bitcoin-cli'],shell=True)
+	subprocess.call(['chmod u+x ' + BitcoinExtractDir + '/bin/bitcoin-qt'],shell=True)
+	subprocess.call(['chmod u+x ' + BitcoinExtractDir + '/bin/bitcoin-cli'],shell=True)

--- a/utils/downloadbitcoin.py
+++ b/utils/downloadbitcoin.py
@@ -1,7 +1,8 @@
 import subprocess
 import os
 
-BitcoinCoreURL = 'https://bitcoincore.org/bin/bitcoin-core-26.0/bitcoin-26.0-x86_64-linux-gnu.tar.gz'
+BitcoinVersion = '26.0'
+BitcoinCoreURL = 'https://bitcoincore.org/bin/bitcoin-core-' + BitcoinVersion + '/bitcoin-' + BitcoinVersion + '-x86_64-linux-gnu.tar.gz'
 BitcoinCorePath = os.path.dirname(BitcoinCoreURL)
 BitcoinCoreFile = os.path.basename(BitcoinCoreURL)
 

--- a/utils/downloadbitcoin.py
+++ b/utils/downloadbitcoin.py
@@ -1,18 +1,24 @@
 import subprocess
 import os
+
+BitcoinCoreURL = 'https://bitcoincore.org/bin/bitcoin-core-26.0/bitcoin-26.0-x86_64-linux-gnu.tar.gz'
+BitcoinCorePath = os.path.dirname(BitcoinCoreURL)
+BitcoinCoreFile = os.path.basename(BitcoinCoreURL)
+
 home = os.getenv("HOME")
 if not os.path.exists(home + "/yeticold/bitcoin"):
-	subprocess.call(['wget https://bitcoincore.org/bin/bitcoin-core-0.21.0/bitcoin-0.21.0-x86_64-linux-gnu.tar.gz -P ~/yeticold/'],shell=True)
-	subprocess.call(['rm ~/yeticold/sigcorrect 2> /dev/null'],shell=True)
-	if not (os.path.exists(home + "/yeticold/SHA256SUMS.asc")):
-		subprocess.call(['sudo wget https://bitcoincore.org/bin/bitcoin-core-0.21.0/SHA256SUMS.asc -P ~/yeticold/'],shell=True)
+	subprocess.call(['wget ' + BitcoinCoreURL + ' -P ~/yeticold/'],shell=True)
+	subprocess.call(['[ -f ~/yeticold/sigcorrect ] && rm ~/yeticold/sigcorrect 2> /dev/null'],shell=True)
+	subprocess.call(['[ -f ~/yeticold/SHASUMS.asc ] && rm ~/yeticold/SHA256SUMS.asc 2> /dev/null'],shell=True)
+	subprocess.call(['wget ' + BitcoinCorePath + '/SHA256SUMS -P ~/yeticold/'],shell=True)
+	subprocess.call(['wget ' + BitcoinCorePath + '/SHA256SUMS.asc -P ~/yeticold/'],shell=True)
 	subprocess.call(['cd ~/yeticold; ./verifySig.sh 2> /dev/null; cd'],shell=True)
 	if not (os.path.exists(home + "/yeticold/sigcorrect")):
 		subprocess.call(['echo "We could not verify the bitcoin core code. This could be from not downloading the signatures or bitcoin core as well as faulty code. Please go to yeticold.slack.com and paste this message in the support section for help."'],shell=True)
 		subprocess.call(['read line'],shell=True)
 	else:
 		subprocess.call(['echo "Successfully verified the bitcoin core code."'],shell=True)
-	subprocess.call(['tar xvzf ~/yeticold/bitcoin-0.21.0-x86_64-linux-gnu.tar.gz -C ~/yeticold'],shell=True)
-	subprocess.call(['mv ~/yeticold/bitcoin-0.21.0 ~/yeticold/bitcoin'],shell=True)
-	subprocess.call(['chmod +x ~/yeticold/bitcoin/bin/bitcoin-qt'],shell=True)
-	subprocess.call(['chmod +x ~/yeticold/bitcoin/bin/bitcoin-cli'],shell=True)
+	subprocess.call(['mkdir ~/yeticold/bitcoin'],shell=True)
+	subprocess.call(['tar -xvzf ~/yeticold/' + BitcoinCoreFile + ' -C ~/yeticold/bitcoin/ --strip-components=1'],shell=True)
+	subprocess.call(['chmod u+x ~/yeticold/bitcoin/bin/bitcoin-qt'],shell=True)
+	subprocess.call(['chmod u+x ~/yeticold/bitcoin/bin/bitcoin-cli'],shell=True)

--- a/utils/downloadbitcoin.py
+++ b/utils/downloadbitcoin.py
@@ -14,7 +14,8 @@ BITCOIN_EXTRACT_DIR = YETI_DIR + '/bitcoin'
 if not os.path.exists(BITCOIN_EXTRACT_DIR):
     subprocess.call(['wget ' + BITCOIN_SOURCE_URL + ' -P ' + YETI_DIR + '/'],shell=True)
     subprocess.call(['[ -f ' + YETI_DIR + '/sigcorrect ] && rm ' + YETI_DIR + '/sigcorrect 2> /dev/null'],shell=True)
-    subprocess.call(['[ -f ' + YETI_DIR + '/SHASUMS.asc ] && rm ' + YETI_DIR + '/SHA256SUMS.asc 2> /dev/null'],shell=True)
+    subprocess.call(['[ -f ' + YETI_DIR + '/SHA256SUMS ] && rm ' + YETI_DIR + '/SHA256SUMS 2> /dev/null'],shell=True)
+    subprocess.call(['[ -f ' + YETI_DIR + '/SHA256SUMS.asc ] && rm ' + YETI_DIR + '/SHA256SUMS.asc 2> /dev/null'],shell=True)
     subprocess.call(['wget ' + BITCOIN_SOURCE_DIR + '/SHA256SUMS -P ' + YETI_DIR + '/'],shell=True)
     subprocess.call(['wget ' + BITCOIN_SOURCE_DIR + '/SHA256SUMS.asc -P ' + YETI_DIR + '/'],shell=True)
     subprocess.call(['cd ' + YETI_DIR + '; ./verifySig.sh 2> /dev/null; cd'],shell=True)

--- a/utils/downloadbitcoin.py
+++ b/utils/downloadbitcoin.py
@@ -1,27 +1,27 @@
 import subprocess
 import os
 
-BitcoinVersion = '26.0'
-BitcoinCoreURL = 'https://bitcoincore.org/bin/bitcoin-core-' + BitcoinVersion + '/bitcoin-' + BitcoinVersion + '-x86_64-linux-gnu.tar.gz'
-BitcoinCorePath = os.path.dirname(BitcoinCoreURL)
-BitcoinCoreFile = os.path.basename(BitcoinCoreURL)
+BITCOIN_VERSION = '26.0'
+BITCOIN_SOURCE_URL = 'https://bitcoincore.org/bin/bitcoin-core-' + BITCOIN_VERSION + '/bitcoin-' + BITCOIN_VERSION + '-x86_64-linux-gnu.tar.gz'
+BITCOIN_SOURCE_DIR = os.path.dirname(BITCOIN_SOURCE_URL)
+BITCOIN_SOURCE_FILENAME = os.path.basename(BITCOIN_SOURCE_URL)
 
-YetiDir = os.getenv("HOME") + '/yeticold'
-BitcoinExtractDir = YetiDir + '/bitcoin'
+YETI_DIR = os.getenv("HOME") + '/yeticold'
+BITCOIN_EXTRACT_DIR = YETI_DIR + '/bitcoin'
 
-if not os.path.exists(BitcoinExtractDir):
-	subprocess.call(['wget ' + BitcoinCoreURL + ' -P ' + YetiDir + '/'],shell=True)
-	subprocess.call(['[ -f ' + YetiDir + '/sigcorrect ] && rm ' + YetiDir + '/sigcorrect 2> /dev/null'],shell=True)
-	subprocess.call(['[ -f ' + YetiDir + '/SHASUMS.asc ] && rm ' + YetiDir + '/SHA256SUMS.asc 2> /dev/null'],shell=True)
-	subprocess.call(['wget ' + BitcoinCorePath + '/SHA256SUMS -P ' + YetiDir + '/'],shell=True)
-	subprocess.call(['wget ' + BitcoinCorePath + '/SHA256SUMS.asc -P ' + YetiDir + '/'],shell=True)
-	subprocess.call(['cd ' + YetiDir + '; ./verifySig.sh 2> /dev/null; cd'],shell=True)
-	if not (os.path.exists(YetiDir + '/sigcorrect')):
-		subprocess.call(['echo "We could not verify the bitcoin core code. This could be from not downloading the signatures or bitcoin core as well as faulty code. Please go to yeticold.slack.com and paste this message in the support section for help."'],shell=True)
-		subprocess.call(['read line'],shell=True)
-	else:
-		subprocess.call(['echo "Successfully verified the bitcoin core code."'],shell=True)
-	subprocess.call(['mkdir ' + BitcoinExtractDir],shell=True)
-	subprocess.call(['tar -xvzf ' + YetiDir + '/' + BitcoinCoreFile + ' -C ' + BitcoinExtractDir + '/ --strip-components=1'],shell=True)
-	subprocess.call(['chmod u+x ' + BitcoinExtractDir + '/bin/bitcoin-qt'],shell=True)
-	subprocess.call(['chmod u+x ' + BitcoinExtractDir + '/bin/bitcoin-cli'],shell=True)
+if not os.path.exists(BITCOIN_EXTRACT_DIR):
+    subprocess.call(['wget ' + BITCOIN_SOURCE_URL + ' -P ' + YETI_DIR + '/'],shell=True)
+    subprocess.call(['[ -f ' + YETI_DIR + '/sigcorrect ] && rm ' + YETI_DIR + '/sigcorrect 2> /dev/null'],shell=True)
+    subprocess.call(['[ -f ' + YETI_DIR + '/SHASUMS.asc ] && rm ' + YETI_DIR + '/SHA256SUMS.asc 2> /dev/null'],shell=True)
+    subprocess.call(['wget ' + BITCOIN_SOURCE_DIR + '/SHA256SUMS -P ' + YETI_DIR + '/'],shell=True)
+    subprocess.call(['wget ' + BITCOIN_SOURCE_DIR + '/SHA256SUMS.asc -P ' + YETI_DIR + '/'],shell=True)
+    subprocess.call(['cd ' + YETI_DIR + '; ./verifySig.sh 2> /dev/null; cd'],shell=True)
+    if not os.path.exists(YETI_DIR + '/sigcorrect'):
+        subprocess.call(['echo "We could not verify the bitcoin core code. This could be from not downloading the signatures or bitcoin core as well as faulty code. Please go to yeticold.slack.com and paste this message in the support section for help."'],shell=True)
+        subprocess.call(['read line'],shell=True)
+    else:
+        subprocess.call(['echo "Successfully verified the bitcoin core code."'],shell=True)
+    subprocess.call(['mkdir ' + BITCOIN_EXTRACT_DIR],shell=True)
+    subprocess.call(['tar -xvzf ' + YETI_DIR + '/' + BITCOIN_SOURCE_FILENAME + ' -C ' + BITCOIN_EXTRACT_DIR + '/ --strip-components=1'],shell=True)
+    subprocess.call(['chmod u+x ' + BITCOIN_EXTRACT_DIR + '/bin/bitcoin-qt'],shell=True)
+    subprocess.call(['chmod u+x ' + BITCOIN_EXTRACT_DIR + '/bin/bitcoin-cli'],shell=True)

--- a/utils/downloadbitcoin.py
+++ b/utils/downloadbitcoin.py
@@ -1,14 +1,14 @@
 import subprocess
 import os
 
-# When new versions of Bitcoin Core are released, bump this variable and update the fingerprints in verifySig.sh.
+# Change this variable when new versions of Bitcoin Core are released.
 BITCOIN_VERSION = '27.0'
 
 BITCOIN_SOURCE_URL = 'https://bitcoincore.org/bin/bitcoin-core-' + BITCOIN_VERSION + '/bitcoin-' + BITCOIN_VERSION + '-x86_64-linux-gnu.tar.gz'
 BITCOIN_SOURCE_DIR = os.path.dirname(BITCOIN_SOURCE_URL)
 BITCOIN_SOURCE_FILENAME = os.path.basename(BITCOIN_SOURCE_URL)
 
-YETI_DIR = os.getenv("HOME") + '/yeticold'
+YETI_DIR = os.getenv('HOME') + '/yeticold'
 BITCOIN_EXTRACT_DIR = YETI_DIR + '/bitcoin'
 
 if not os.path.exists(BITCOIN_EXTRACT_DIR):

--- a/utils/downloadbitcoin.py
+++ b/utils/downloadbitcoin.py
@@ -5,20 +5,22 @@ BitcoinCoreURL = 'https://bitcoincore.org/bin/bitcoin-core-26.0/bitcoin-26.0-x86
 BitcoinCorePath = os.path.dirname(BitcoinCoreURL)
 BitcoinCoreFile = os.path.basename(BitcoinCoreURL)
 
-home = os.getenv("HOME")
-if not os.path.exists(home + "/yeticold/bitcoin"):
-	subprocess.call(['wget ' + BitcoinCoreURL + ' -P ~/yeticold/'],shell=True)
-	subprocess.call(['[ -f ~/yeticold/sigcorrect ] && rm ~/yeticold/sigcorrect 2> /dev/null'],shell=True)
-	subprocess.call(['[ -f ~/yeticold/SHASUMS.asc ] && rm ~/yeticold/SHA256SUMS.asc 2> /dev/null'],shell=True)
-	subprocess.call(['wget ' + BitcoinCorePath + '/SHA256SUMS -P ~/yeticold/'],shell=True)
-	subprocess.call(['wget ' + BitcoinCorePath + '/SHA256SUMS.asc -P ~/yeticold/'],shell=True)
-	subprocess.call(['cd ~/yeticold; ./verifySig.sh 2> /dev/null; cd'],shell=True)
-	if not (os.path.exists(home + "/yeticold/sigcorrect")):
+YetiDir = os.getenv("HOME") + '/yeticold'
+BitcoinExtractDir = YetiDir + '/bitcoin'
+
+if not os.path.exists(BitcoinExtractDir):
+	subprocess.call(['wget ' + BitcoinCoreURL + ' -P ' + YetiDir + '/'],shell=True)
+	subprocess.call(['[ -f ' + YetiDir + '/sigcorrect ] && rm ' + YetiDir + '/sigcorrect 2> /dev/null'],shell=True)
+	subprocess.call(['[ -f ' + YetiDir + '/SHASUMS.asc ] && rm ' + YetiDir + '/SHA256SUMS.asc 2> /dev/null'],shell=True)
+	subprocess.call(['wget ' + BitcoinCorePath + '/SHA256SUMS -P ' + YetiDir + '/'],shell=True)
+	subprocess.call(['wget ' + BitcoinCorePath + '/SHA256SUMS.asc -P ' + YetiDir + '/'],shell=True)
+	subprocess.call(['cd ' + YetiDir + '; ./verifySig.sh 2> /dev/null; cd'],shell=True)
+	if not (os.path.exists(YetiDir + '/sigcorrect')):
 		subprocess.call(['echo "We could not verify the bitcoin core code. This could be from not downloading the signatures or bitcoin core as well as faulty code. Please go to yeticold.slack.com and paste this message in the support section for help."'],shell=True)
 		subprocess.call(['read line'],shell=True)
 	else:
 		subprocess.call(['echo "Successfully verified the bitcoin core code."'],shell=True)
-	subprocess.call(['mkdir ~/yeticold/bitcoin'],shell=True)
-	subprocess.call(['tar -xvzf ~/yeticold/' + BitcoinCoreFile + ' -C ~/yeticold/bitcoin/ --strip-components=1'],shell=True)
-	subprocess.call(['chmod u+x ~/yeticold/bitcoin/bin/bitcoin-qt'],shell=True)
-	subprocess.call(['chmod u+x ~/yeticold/bitcoin/bin/bitcoin-cli'],shell=True)
+	subprocess.call(['mkdir ' + BitcoinExtractDir],shell=True)
+	subprocess.call(['tar -xvzf ' + YetiDir + '/' + BitcoinCoreFile + ' -C ' + BitcoinExtractDir + '/ --strip-components=1'],shell=True)
+	subprocess.call(['chmod u+x ' + YetiDir + '/bin/bitcoin-qt'],shell=True)
+	subprocess.call(['chmod u+x ' + YetiDir + '/bin/bitcoin-cli'],shell=True)

--- a/utils/downloadbitcoin.py
+++ b/utils/downloadbitcoin.py
@@ -1,7 +1,9 @@
 import subprocess
 import os
 
-BITCOIN_VERSION = '26.0'
+# When new versions of Bitcoin Core are released, bump this variable and update the fingerprints in verifySig.sh.
+BITCOIN_VERSION = '27.0'
+
 BITCOIN_SOURCE_URL = 'https://bitcoincore.org/bin/bitcoin-core-' + BITCOIN_VERSION + '/bitcoin-' + BITCOIN_VERSION + '-x86_64-linux-gnu.tar.gz'
 BITCOIN_SOURCE_DIR = os.path.dirname(BITCOIN_SOURCE_URL)
 BITCOIN_SOURCE_FILENAME = os.path.basename(BITCOIN_SOURCE_URL)

--- a/verifySig.sh
+++ b/verifySig.sh
@@ -3,29 +3,31 @@
 check_sig=$(sha256sum --ignore-missing --check SHA256SUMS | grep --count 'bitcoin-.*-x86_64-linux-gnu.tar.gz: OK')
 echo "${check_sig}"
 
-curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/laanwj.gpg | gpg --import -
-rsa_key_1="9DEAE0DC7063249FB05474681E4AED62986CD25D"
-fingerprint_1="71A3 B167 3540 5025 D447 E8F2 7481 0B01 2346 C9A6"
-curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/fanquake.gpg | gpg --import -
-rsa_key_2="CFB16E21C950F67FA95E558F2EEB9F5CC09526C1"
-fingerprint_2="E777 299F C265 DD04 7930 70EB 944D 35F9 AC3D B76A"
-curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/Sjors.gpg | gpg --import -
-rsa_key_3="ED9BDF7AD6A55E232E84524257FF9BDBCC301009"
-fingerprint_3="ED9B DF7A D6A5 5E23 2E84 5242 57FF 9BDB CC30 1009"
-curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/achow101.gpg | gpg --import -
-rsa_key_4="152812300785C96444D3334D17565732E08E5E41"
-fingerprint_4="1528 1230 0785 C964 44D3 334D 1756 5732 E08E 5E41"
+if [ "${check_sig}" -eq 1 ]; then
+  curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/laanwj.gpg | gpg --import -
+  rsa_key_1="9DEAE0DC7063249FB05474681E4AED62986CD25D"
+  fingerprint_1="71A3 B167 3540 5025 D447 E8F2 7481 0B01 2346 C9A6"
+  curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/fanquake.gpg | gpg --import -
+  rsa_key_2="CFB16E21C950F67FA95E558F2EEB9F5CC09526C1"
+  fingerprint_2="E777 299F C265 DD04 7930 70EB 944D 35F9 AC3D B76A"
+  curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/Sjors.gpg | gpg --import -
+  rsa_key_3="ED9BDF7AD6A55E232E84524257FF9BDBCC301009"
+  fingerprint_3="ED9B DF7A D6A5 5E23 2E84 5242 57FF 9BDB CC30 1009"
+  curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/achow101.gpg | gpg --import -
+  rsa_key_4="152812300785C96444D3334D17565732E08E5E41"
+  fingerprint_4="1528 1230 0785 C964 44D3 334D 1756 5732 E08E 5E41"
 
-verify_result="$(gpg --verify SHA256SUMS.asc 2>&1)"
-good_signatures="$(echo "${verify_result}" | grep --count 'Good signature')"
-good_rsa_keys="$(echo "${verify_result}" | grep 'using RSA key ' | grep -oE "${rsa_key_1}|${rsa_key_2}|${rsa_key_3}|${rsa_key_4}" | wc -l)"
-good_fingerprints="$(echo ${verify_result} | grep 'Primary key fingerprint' | grep -oE "${fingerprint_1}|${fingerprint_2}|${fingerprint_3}|${fingerprint_4}" | wc -l)"
-echo "${verify_result}"
-echo "${good_signatures}"
-echo "${good_rsa_keys}"
-echo "${good_fingerprints}"
+  verify_result="$(gpg --verify SHA256SUMS.asc 2>&1)"
+  good_signatures="$(echo "${verify_result}" | grep --count 'Good signature')"
+  good_rsa_keys="$(echo "${verify_result}" | grep 'using RSA key ' | grep -oE "${rsa_key_1}|${rsa_key_2}|${rsa_key_3}|${rsa_key_4}" | wc -l)"
+  good_fingerprints="$(echo ${verify_result} | grep 'Primary key fingerprint' | grep -oE "${fingerprint_1}|${fingerprint_2}|${fingerprint_3}|${fingerprint_4}" | wc -l)"
+  echo "${verify_result}"
+  echo "${good_signatures}"
+  echo "${good_rsa_keys}"
+  echo "${good_fingerprints}"
 
-if [ "${check_sig}" -eq 1 ] && [ "${good_signatures}" -ge 4 ] && [ "${good_rsa_keys}" -ge 4 ] && [ "${good_fingerprints}" -ge 4 ]
-then
-  touch "${HOME}"/yeticold/sigcorrect
+  reqd_sigs="4"
+  if [ "${good_signatures}" -ge "${reqd_sigs}" ] && [ "${good_rsa_keys}" -ge "${reqd_sigs}" ] && [ "${good_fingerprints}" -ge "${reqd_sigs}" ]; then
+    touch "${HOME}"/yeticold/sigcorrect
+  fi
 fi

--- a/verifySig.sh
+++ b/verifySig.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
 
-CheckSig=$(sha256sum --ignore-missing --check SHA256SUMS | grep --count 'bitcoin-.*-x86_64-linux-gnu.tar.gz: OK')
-echo "${CheckSig}"
+check_sig=$(sha256sum --ignore-missing --check SHA256SUMS | grep --count 'bitcoin-.*-x86_64-linux-gnu.tar.gz: OK')
+echo "${check_sig}"
 
 curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/laanwj.gpg | gpg --import -
-RSAKey1="9DEAE0DC7063249FB05474681E4AED62986CD25D"
-Fingerprint1="71A3 B167 3540 5025 D447 E8F2 7481 0B01 2346 C9A6"
+rsa_key_1="9DEAE0DC7063249FB05474681E4AED62986CD25D"
+fingerprint_1="71A3 B167 3540 5025 D447 E8F2 7481 0B01 2346 C9A6"
 curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/fanquake.gpg | gpg --import -
-RSAKey2="CFB16E21C950F67FA95E558F2EEB9F5CC09526C1"
-Fingerprint2="E777 299F C265 DD04 7930 70EB 944D 35F9 AC3D B76A"
+rsa_key_2="CFB16E21C950F67FA95E558F2EEB9F5CC09526C1"
+fingerprint_2="E777 299F C265 DD04 7930 70EB 944D 35F9 AC3D B76A"
 curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/Sjors.gpg | gpg --import -
-RSAKey3="ED9BDF7AD6A55E232E84524257FF9BDBCC301009"
-Fingerprint3="ED9B DF7A D6A5 5E23 2E84 5242 57FF 9BDB CC30 1009"
+rsa_key_3="ED9BDF7AD6A55E232E84524257FF9BDBCC301009"
+fingerprint_3="ED9B DF7A D6A5 5E23 2E84 5242 57FF 9BDB CC30 1009"
 curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/achow101.gpg | gpg --import -
-RSAKey4="152812300785C96444D3334D17565732E08E5E41"
-Fingerprint4="1528 1230 0785 C964 44D3 334D 1756 5732 E08E 5E41"
+rsa_key_4="152812300785C96444D3334D17565732E08E5E41"
+fingerprint_4="1528 1230 0785 C964 44D3 334D 1756 5732 E08E 5E41"
 
-verifyResult="$(gpg --verify SHA256SUMS.asc 2>&1)"
-goodSignatures="$(echo "${verifyResult}" | grep --count 'Good signature')"
-goodRSAKeys="$(echo "${verifyResult}" | grep 'using RSA key ' | grep -oE "${RSAKey1}|${RSAKey2}|${RSAKey3}|${RSAKey4}" | wc -l)"
-goodFingerprints="$(echo ${verifyResult} | grep 'Primary key fingerprint' | grep -oE "${Fingerprint1}|${Fingerprint2}|${Fingerprint3}|${Fingerprint4}" | wc -l)"
-echo "${verifyResult}"
-echo "${goodSignatures}"
-echo "${goodRSAKeys}"
-echo "${goodFingerprints}"
+verify_result="$(gpg --verify SHA256SUMS.asc 2>&1)"
+good_signatures="$(echo "${verify_result}" | grep --count 'Good signature')"
+good_rsa_keys="$(echo "${verify_result}" | grep 'using RSA key ' | grep -oE "${rsa_key_1}|${rsa_key_2}|${rsa_key_3}|${rsa_key_4}" | wc -l)"
+good_fingerprints="$(echo ${verify_result} | grep 'Primary key fingerprint' | grep -oE "${fingerprint_1}|${fingerprint_2}|${fingerprint_3}|${fingerprint_4}" | wc -l)"
+echo "${verify_result}"
+echo "${good_signatures}"
+echo "${good_rsa_keys}"
+echo "${good_fingerprints}"
 
-if [ "${CheckSig}" -eq 1 ] && [ "${goodSignatures}" -ge 4 ] && [ "${goodRSAKeys}" -ge 4 ] && [ "${goodFingerprints}" -ge 4 ]
+if [ "${check_sig}" -eq 1 ] && [ "${good_signatures}" -ge 4 ] && [ "${good_rsa_keys}" -ge 4 ] && [ "${good_fingerprints}" -ge 4 ]
 then
   touch "${HOME}"/yeticold/sigcorrect
 fi

--- a/verifySig.sh
+++ b/verifySig.sh
@@ -1,18 +1,25 @@
-Sig=$(sha256sum --ignore-missing --check SHA256SUMS.asc)
-CheckSig=$(echo ${Sig} | grep 'bitcoin-0.21.0-x86_64-linux-gnu.tar.gz: OK' -c)
+#!/bin/bash
+
+CheckSig=$(sha256sum --ignore-missing --check SHA256SUMS | grep --count 'bitcoin-.*-x86_64-linux-gnu.tar.gz: OK')
 echo ${CheckSig}
-gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 01EA5486DE18A882D4C2684590C8019E36C2E964
+
+curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/laanwj.gpg | gpg --import -
+RSAKey1="9DEAE0DC7063249FB05474681E4AED62986CD25D"
+Fingerprint1="71A3 B167 3540 5025 D447 E8F2 7481 0B01 2346 C9A6"
+curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/fanquake.gpg | gpg --import -
+RSAKey2="CFB16E21C950F67FA95E558F2EEB9F5CC09526C1"
+Fingerprint2="E777 299F C265 DD04 7930 70EB 944D 35F9 AC3D B76A"
 
 verifyResult=$(gpg --verify SHA256SUMS.asc 2>&1)
-goodSignature=$(echo ${verifyResult} | grep 'Good signature' -c)
-goodFingerprint=$(echo ${verifyResult} | grep "Primary key fingerprint: 01EA 5486 DE18 A882 D4C2 6845 90C8 019E 36C2 E964" -c)
+goodSignature=$(echo ${verifyResult} | grep -o 'Good signature' | wc -l)
+goodRSAKey=$(echo ${verifyResult} | grep 'using RSA key ' | grep -oE "${RSAKey1}|${RSAKey2}" | wc -l)
+goodFingerprint=$(echo ${verifyResult} | grep 'Primary key fingerprint' | grep -oE "${Fingerprint1}|${Fingerprint2}" | wc -l)
 echo ${verifyResult}
 echo ${goodSignature}
+echo ${goodRSAKey}
 echo ${goodFingerprint}
 
-if [ ${CheckSig} -eq 1 ] && [ ${goodSignature} -eq 1 ] && [ ${goodFingerprint} -eq 1 ]
+if [ ${CheckSig} -eq 1 ] && [ ${goodSignature} -ge 2 ] && [ ${goodRSAKey} -ge 2 ] && [ ${goodFingerprint} -ge 2 ]
 then
-  touch ~/yeticold/sigcorrect
+  touch ${HOME}/yeticold/sigcorrect
 fi
-
-

--- a/verifySig.sh
+++ b/verifySig.sh
@@ -5,17 +5,17 @@ echo "${CHECK_SIG}"
 
 if [ "${CHECK_SIG}" -eq 1 ]; then
   curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/laanwj.gpg | gpg --import -
-  readonly RSA_KEY_1="9DEAE0DC7063249FB05474681E4AED62986CD25D"
-  readonly FINGERPRINT_1="71A3 B167 3540 5025 D447 E8F2 7481 0B01 2346 C9A6"
+  readonly RSA_KEY_1='9DEAE0DC7063249FB05474681E4AED62986CD25D'
+  readonly FINGERPRINT_1='71A3 B167 3540 5025 D447 E8F2 7481 0B01 2346 C9A6'
   curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/fanquake.gpg | gpg --import -
-  readonly RSA_KEY_2="CFB16E21C950F67FA95E558F2EEB9F5CC09526C1"
-  readonly FINGERPRINT_2="E777 299F C265 DD04 7930 70EB 944D 35F9 AC3D B76A"
+  readonly RSA_KEY_2='CFB16E21C950F67FA95E558F2EEB9F5CC09526C1'
+  readonly FINGERPRINT_2='E777 299F C265 DD04 7930 70EB 944D 35F9 AC3D B76A'
   curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/Sjors.gpg | gpg --import -
-  readonly RSA_KEY_3="ED9BDF7AD6A55E232E84524257FF9BDBCC301009"
-  readonly FINGERPRINT_3="ED9B DF7A D6A5 5E23 2E84 5242 57FF 9BDB CC30 1009"
+  readonly RSA_KEY_3='ED9BDF7AD6A55E232E84524257FF9BDBCC301009'
+  readonly FINGERPRINT_3='ED9B DF7A D6A5 5E23 2E84 5242 57FF 9BDB CC30 1009'
   curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/achow101.gpg | gpg --import -
-  readonly RSA_KEY_4="152812300785C96444D3334D17565732E08E5E41"
-  readonly FINGERPRINT_4="1528 1230 0785 C964 44D3 334D 1756 5732 E08E 5E41"
+  readonly RSA_KEY_4='152812300785C96444D3334D17565732E08E5E41'
+  readonly FINGERPRINT_4='1528 1230 0785 C964 44D3 334D 1756 5732 E08E 5E41'
 
   readonly VERIFY_RESULT="$(gpg --verify SHA256SUMS.asc 2>&1)"
   readonly GOOD_SIGNATURES="$(echo "${VERIFY_RESULT}" | grep --count 'Good signature')"
@@ -26,7 +26,7 @@ if [ "${CHECK_SIG}" -eq 1 ]; then
   echo "${GOOD_RSA_KEYS}"
   echo "${GOOD_FINGERPRINTS}"
 
-  readonly REQD_SIGS="4"
+  readonly REQD_SIGS='4'
   if [ "${GOOD_SIGNATURES}" -ge "${REQD_SIGS}" ] && [ "${GOOD_RSA_KEYS}" -ge "${REQD_SIGS}" ] && [ "${GOOD_FINGERPRINTS}" -ge "${REQD_SIGS}" ]; then
     touch "${HOME}/yeticold/sigcorrect"
   fi

--- a/verifySig.sh
+++ b/verifySig.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CheckSig=$(sha256sum --ignore-missing --check SHA256SUMS | grep --count 'bitcoin-.*-x86_64-linux-gnu.tar.gz: OK')
-echo ${CheckSig}
+echo "${CheckSig}"
 
 curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/laanwj.gpg | gpg --import -
 RSAKey1="9DEAE0DC7063249FB05474681E4AED62986CD25D"
@@ -10,16 +10,16 @@ curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/fanqu
 RSAKey2="CFB16E21C950F67FA95E558F2EEB9F5CC09526C1"
 Fingerprint2="E777 299F C265 DD04 7930 70EB 944D 35F9 AC3D B76A"
 
-verifyResult=$(gpg --verify SHA256SUMS.asc 2>&1)
-goodSignature=$(echo ${verifyResult} | grep -o 'Good signature' | wc -l)
-goodRSAKey=$(echo ${verifyResult} | grep 'using RSA key ' | grep -oE "${RSAKey1}|${RSAKey2}" | wc -l)
-goodFingerprint=$(echo ${verifyResult} | grep 'Primary key fingerprint' | grep -oE "${Fingerprint1}|${Fingerprint2}" | wc -l)
-echo ${verifyResult}
-echo ${goodSignature}
-echo ${goodRSAKey}
-echo ${goodFingerprint}
+verifyResult="$(gpg --verify SHA256SUMS.asc 2>&1)"
+goodSignatures="$(echo "${verifyResult}" | grep --count 'Good signature')"
+goodRSAKeys="$(echo "${verifyResult}" | grep 'using RSA key ' | grep -oE "${RSAKey1}|${RSAKey2}" | wc -l)"
+goodFingerprints="$(echo ${verifyResult} | grep 'Primary key fingerprint' | grep -oE "${Fingerprint1}|${Fingerprint2}" | wc -l)"
+echo "${verifyResult}"
+echo "${goodSignatures}"
+echo "${goodRSAKeys}"
+echo "${goodFingerprints}"
 
-if [ ${CheckSig} -eq 1 ] && [ ${goodSignature} -ge 2 ] && [ ${goodRSAKey} -ge 2 ] && [ ${goodFingerprint} -ge 2 ]
+if [ "${CheckSig}" -eq 1 ] && [ "${goodSignatures}" -ge 2 ] && [ "${goodRSAKeys}" -ge 2 ] && [ "${goodFingerprints}" -ge 2 ]
 then
-  touch ${HOME}/yeticold/sigcorrect
+  touch "${HOME}"/yeticold/sigcorrect
 fi

--- a/verifySig.sh
+++ b/verifySig.sh
@@ -1,33 +1,33 @@
 #!/bin/bash
 
-check_sig=$(sha256sum --ignore-missing --check SHA256SUMS | grep --count 'bitcoin-.*-x86_64-linux-gnu.tar.gz: OK')
-echo "${check_sig}"
+readonly CHECK_SIG=$(sha256sum --ignore-missing --check SHA256SUMS | grep --count 'bitcoin-.*-x86_64-linux-gnu.tar.gz: OK')
+echo "${CHECK_SIG}"
 
-if [ "${check_sig}" -eq 1 ]; then
+if [ "${CHECK_SIG}" -eq 1 ]; then
   curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/laanwj.gpg | gpg --import -
-  rsa_key_1="9DEAE0DC7063249FB05474681E4AED62986CD25D"
-  fingerprint_1="71A3 B167 3540 5025 D447 E8F2 7481 0B01 2346 C9A6"
+  readonly RSA_KEY_1="9DEAE0DC7063249FB05474681E4AED62986CD25D"
+  readonly FINGERPRINT_1="71A3 B167 3540 5025 D447 E8F2 7481 0B01 2346 C9A6"
   curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/fanquake.gpg | gpg --import -
-  rsa_key_2="CFB16E21C950F67FA95E558F2EEB9F5CC09526C1"
-  fingerprint_2="E777 299F C265 DD04 7930 70EB 944D 35F9 AC3D B76A"
+  readonly RSA_KEY_2="CFB16E21C950F67FA95E558F2EEB9F5CC09526C1"
+  readonly FINGERPRINT_2="E777 299F C265 DD04 7930 70EB 944D 35F9 AC3D B76A"
   curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/Sjors.gpg | gpg --import -
-  rsa_key_3="ED9BDF7AD6A55E232E84524257FF9BDBCC301009"
-  fingerprint_3="ED9B DF7A D6A5 5E23 2E84 5242 57FF 9BDB CC30 1009"
+  readonly RSA_KEY_3="ED9BDF7AD6A55E232E84524257FF9BDBCC301009"
+  readonly FINGERPRINT_3="ED9B DF7A D6A5 5E23 2E84 5242 57FF 9BDB CC30 1009"
   curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/achow101.gpg | gpg --import -
-  rsa_key_4="152812300785C96444D3334D17565732E08E5E41"
-  fingerprint_4="1528 1230 0785 C964 44D3 334D 1756 5732 E08E 5E41"
+  readonly RSA_KEY_4="152812300785C96444D3334D17565732E08E5E41"
+  readonly FINGERPRINT_4="1528 1230 0785 C964 44D3 334D 1756 5732 E08E 5E41"
 
-  verify_result="$(gpg --verify SHA256SUMS.asc 2>&1)"
-  good_signatures="$(echo "${verify_result}" | grep --count 'Good signature')"
-  good_rsa_keys="$(echo "${verify_result}" | grep 'using RSA key ' | grep -oE "${rsa_key_1}|${rsa_key_2}|${rsa_key_3}|${rsa_key_4}" | wc -l)"
-  good_fingerprints="$(echo ${verify_result} | grep 'Primary key fingerprint' | grep -oE "${fingerprint_1}|${fingerprint_2}|${fingerprint_3}|${fingerprint_4}" | wc -l)"
-  echo "${verify_result}"
-  echo "${good_signatures}"
-  echo "${good_rsa_keys}"
-  echo "${good_fingerprints}"
+  readonly VERIFY_RESULT="$(gpg --verify SHA256SUMS.asc 2>&1)"
+  readonly GOOD_SIGNATURES="$(echo "${VERIFY_RESULT}" | grep --count 'Good signature')"
+  readonly GOOD_RSA_KEYS="$(echo "${VERIFY_RESULT}" | grep 'using RSA key ' | grep -oE "${RSA_KEY_1}|${RSA_KEY_2}|${RSA_KEY_3}|${RSA_KEY_4}" | wc -l)"
+  readonly GOOD_FINGERPRINTS="$(echo ${VERIFY_RESULT} | grep 'Primary key fingerprint' | grep -oE "${FINGERPRINT_1}|${FINGERPRINT_2}|${FINGERPRINT_3}|${FINGERPRINT_4}" | wc -l)"
+  echo "${VERIFY_RESULT}"
+  echo "${GOOD_SIGNATURES}"
+  echo "${GOOD_RSA_KEYS}"
+  echo "${GOOD_FINGERPRINTS}"
 
-  reqd_sigs="4"
-  if [ "${good_signatures}" -ge "${reqd_sigs}" ] && [ "${good_rsa_keys}" -ge "${reqd_sigs}" ] && [ "${good_fingerprints}" -ge "${reqd_sigs}" ]; then
-    touch "${HOME}"/yeticold/sigcorrect
+  readonly REQD_SIGS="4"
+  if [ "${GOOD_SIGNATURES}" -ge "${REQD_SIGS}" ] && [ "${GOOD_RSA_KEYS}" -ge "${REQD_SIGS}" ] && [ "${GOOD_FINGERPRINTS}" -ge "${REQD_SIGS}" ]; then
+    touch "${HOME}/yeticold/sigcorrect"
   fi
 fi

--- a/verifySig.sh
+++ b/verifySig.sh
@@ -9,17 +9,23 @@ Fingerprint1="71A3 B167 3540 5025 D447 E8F2 7481 0B01 2346 C9A6"
 curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/fanquake.gpg | gpg --import -
 RSAKey2="CFB16E21C950F67FA95E558F2EEB9F5CC09526C1"
 Fingerprint2="E777 299F C265 DD04 7930 70EB 944D 35F9 AC3D B76A"
+curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/Sjors.gpg | gpg --import -
+RSAKey3="ED9BDF7AD6A55E232E84524257FF9BDBCC301009"
+Fingerprint3="ED9B DF7A D6A5 5E23 2E84 5242 57FF 9BDB CC30 1009"
+curl -fsSL https://github.com/bitcoin-core/guix.sigs/raw/main/builder-keys/achow101.gpg | gpg --import -
+RSAKey4="152812300785C96444D3334D17565732E08E5E41"
+Fingerprint4="1528 1230 0785 C964 44D3 334D 1756 5732 E08E 5E41"
 
 verifyResult="$(gpg --verify SHA256SUMS.asc 2>&1)"
 goodSignatures="$(echo "${verifyResult}" | grep --count 'Good signature')"
-goodRSAKeys="$(echo "${verifyResult}" | grep 'using RSA key ' | grep -oE "${RSAKey1}|${RSAKey2}" | wc -l)"
-goodFingerprints="$(echo ${verifyResult} | grep 'Primary key fingerprint' | grep -oE "${Fingerprint1}|${Fingerprint2}" | wc -l)"
+goodRSAKeys="$(echo "${verifyResult}" | grep 'using RSA key ' | grep -oE "${RSAKey1}|${RSAKey2}|${RSAKey3}|${RSAKey4}" | wc -l)"
+goodFingerprints="$(echo ${verifyResult} | grep 'Primary key fingerprint' | grep -oE "${Fingerprint1}|${Fingerprint2}|${Fingerprint3}|${Fingerprint4}" | wc -l)"
 echo "${verifyResult}"
 echo "${goodSignatures}"
 echo "${goodRSAKeys}"
 echo "${goodFingerprints}"
 
-if [ "${CheckSig}" -eq 1 ] && [ "${goodSignatures}" -ge 2 ] && [ "${goodRSAKeys}" -ge 2 ] && [ "${goodFingerprints}" -ge 2 ]
+if [ "${CheckSig}" -eq 1 ] && [ "${goodSignatures}" -ge 4 ] && [ "${goodRSAKeys}" -ge 4 ] && [ "${goodFingerprints}" -ge 4 ]
 then
   touch "${HOME}"/yeticold/sigcorrect
 fi


### PR DESCRIPTION
This PR does the following new functionality:
- Change the Core URL from `v0.21.0` to `v27.0`
- Use a single variable for the Core version to reduce the developer effort for future up-versioning
- Remove existing `SHA256SUMS` and `SHA256SUMS.asc`
- Extract the tarball directly to target directory
- Set `chmod +x` only for the current user
- Import signer keys from `bitcoin-core/guide.sigs` repo
- Add support for multiple >=4 good signatures

Additionally, this PR contains the following refactors:
- Refactor of `downloadbitcoin.py` to use variables for `yeticold` and `bitcoin/` directories 
- Refactor of `verifySig.sh` to use bash best practices
- Refactor of `downloadbitcoin.py` to use standard Python-style case for constants
- Refactor of `verifySig.sh` to use standard bash-style case for variables

Existing users should be able to run the new code without anything other than copy-paste. No manually deleting, no re-installing Ubuntu, etc.

**Keeping PR in a draft state until I perform a full UX test of Level 3 and verify backwards-compatibility.**

TODO:
 - full test of Level 3
 - verify change is backwards-compatible for existing Yeti users