### PR TITLE
fix(deps): install curl dependency for GPG key import

### DIFF
--- a/initialize.py
+++ b/initialize.py
@@ -35,7 +35,7 @@ else:
         # Use apt instead of apt-get since apt is more suitable for end users and has a graphical progress bar
         print("Installing updates. This could take an hour without feedback.")
         subprocess.run('sudo unattended-upgrade', shell=True, check=False)
-        subprocess.run('yes | sudo apt install python3-pip tor brasero', shell=True, check=False)
+        subprocess.run('yes | sudo apt install python3-pip tor brasero curl', shell=True, check=False)
         subprocess.run('pip3 install --upgrade pip', shell=True, check=False)
     subprocess.run('python3 ~/yeticold/utils/downloadbitcoin.py', shell=True, check=False)
     # Check if required python packages have been installed


### PR DESCRIPTION
Closes https://github.com/JWWeatherman/yeticold/issues/180.

The signature verification script includes a step where it downloads the signing keys for the trusted signers.

That key import step fails because the `curl` dependency isn't installed by default on Ubuntu.

There are two ways to fix this:
- add curl
- rewrite the GPG verification script to use wget instead

Choosing the approach of installing curl since it's a commonly used dependency, and rewriting the verification script has a chance to induce regressions.